### PR TITLE
Fix #3 - Enable center frequencies > 2^31-1  

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,7 +261,23 @@ auto main(int argc, char **argv) -> int {
 
   cfg.lookupValue("rp.sdr.search_sample_rate_hz", sample_rate);
   search_sample_rate = sample_rate;
-  cfg.lookupValue("rp.sdr.center_frequency_hz", frequency);
+
+  unsigned long long center_frequency = frequency;
+  if (!cfg.lookupValue("rp.sdr.center_frequency_hz", center_frequency)) {
+    spdlog::error("Unable to parse center_frequency_hz - values must have a ‘L’ character appended");
+    exit(1);
+  }
+  // We needed unsigned long long for correct parsing,
+  // but unsigned is required
+  if (center_frequency <= UINT_MAX) {
+     frequency = static_cast<unsigned>(center_frequency);
+  } else {
+    spdlog::error("Configured center_frequency_hz is {}, maximal value supported is {}.",
+        center_frequency, UINT_MAX);
+    exit(1);
+  }
+
+
   cfg.lookupValue("rp.sdr.normalized_gain", gain);
   cfg.lookupValue("rp.sdr.antenna", antenna);
 

--- a/supporting_files/obeca.conf
+++ b/supporting_files/obeca.conf
@@ -1,6 +1,6 @@
 rp: {
   sdr: {
-    center_frequency_hz = 943200000;
+    center_frequency_hz = 943200000L;
     filter_bandwidth_hz =   5000000;
     search_sample_rate =    7680000;
 


### PR DESCRIPTION
Implements the suggested solution in #3. Enforces to append 'L' character to value in the config file and therefore breaks with old configuration files. Having support for values with and without the 'L' character is not easily possible with libconfig. An error message is printed if a value is configured without the 'L' character:

`rp[207]: Unable to parse center_frequency_hz - values must have a ‘L’ character appended`

Signed-off-by: Andreas Dotzler <andreas.dotzler@cadami.net>